### PR TITLE
SMAL-118: Updating Size validation to be based on Journey selected (#10)

### DIFF
--- a/src/EPR.RegistrationValidation.Application/Services/ValidationService.cs
+++ b/src/EPR.RegistrationValidation.Application/Services/ValidationService.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Reflection;
 using EPR.RegistrationValidation.Application.Clients;
@@ -43,7 +42,6 @@ public class ValidationService : IValidationService
     private readonly PartnerDataRowValidator _partnerDataRowValidator;
     private readonly ColumnMetaDataProvider _metaDataProvider;
     private readonly ValidationSettings _validationSettings;
-    private readonly RegistrationSettings _registrationSettings;
     private readonly ILogger<ValidationService> _logger;
     private readonly IFeatureManager _featureManager;
     private readonly ICompanyDetailsApiClient _companyDetailsApiClient;
@@ -71,7 +69,6 @@ public class ValidationService : IValidationService
         _logger = logger;
         _featureManager = featureManager;
         _validationSettings = config.ValidationSettings.Value;
-        _registrationSettings = config.RegistrationSettings.Value;
         _subsidiaryDetailsRequestBuilder = subsidiaryDetailsRequestBuilder;
     }
 
@@ -81,7 +78,12 @@ public class ValidationService : IValidationService
 
         var organisationFileDetails = await _submissionApiClient.GetOrganisationFileDetails(blobQueueMessage.SubmissionId, blobQueueMessage.BlobName);
 
-        var rowValidationResult = await ValidateRowsAsync(rows, !string.IsNullOrEmpty(blobQueueMessage.ComplianceSchemeId), organisationFileDetails.SubmissionPeriod);
+        var rowValidationResult = await ValidateRowsAsync(
+            rows,
+            !string.IsNullOrEmpty(blobQueueMessage.ComplianceSchemeId),
+            organisationFileDetails.SubmissionPeriod,
+            organisationFileDetails.RegistrationJourney);
+
         validationErrors.AddRange(rowValidationResult.ValidationErrors);
 
         var organisationSubsidiaryRelationshipsResult = ValidateOrganisationSubsidiaryRelationships(rows, rowValidationResult.TotalErrors);
@@ -159,13 +161,15 @@ public class ValidationService : IValidationService
         return validationWarnings;
     }
 
-    public async Task<(int TotalErrors, List<RegistrationValidationError> ValidationErrors)> ValidateRowsAsync(IList<OrganisationDataRow> rows, bool uploadedByComplianceScheme, string submissionPeriod)
+    public async Task<(int TotalErrors, List<RegistrationValidationError> ValidationErrors)> ValidateRowsAsync(IList<OrganisationDataRow> rows, bool uploadedByComplianceScheme, string submissionPeriod, string? registrationJourney)
     {
-        bool isSubmissionPeriod2026 = string.Equals(submissionPeriod, _registrationSettings.SubmissionPeriod2026, StringComparison.OrdinalIgnoreCase);
-        _organisationDataRowValidator.RegisterValidators(uploadedByComplianceScheme, isSubmissionPeriod2026, _registrationSettings.SmallProducersRegStartTime2026, _registrationSettings.SmallProducersRegEndTime2026);
+        await _organisationDataRowValidator.RegisterValidators(
+                                                            uploadedByComplianceScheme,
+                                                            registrationJourney);
 
         List<RegistrationValidationError> validationErrors = new();
         int totalErrors = 0;
+
         foreach (var row in rows.TakeWhile(_ => totalErrors < _validationSettings.ErrorLimit))
         {
             var result = await _organisationDataRowValidator.ValidateAsync(row);
@@ -189,8 +193,8 @@ public class ValidationService : IValidationService
                 error.ColumnErrors.Add(new ColumnValidationError
                 {
                     ErrorCode = validationError.ErrorCode,
-                    ColumnIndex = columnMeta?.Index,
-                    ColumnName = columnMeta?.Name,
+                    ColumnIndex = columnMeta.Index,
+                    ColumnName = columnMeta.Name,
                 });
 
                 LogValidationWarning(row.LineNumber, validationError);

--- a/src/EPR.RegistrationValidation.Application/Validators/OrganisationDataRowValidator.cs
+++ b/src/EPR.RegistrationValidation.Application/Validators/OrganisationDataRowValidator.cs
@@ -10,20 +10,27 @@ using Microsoft.FeatureManagement;
 public class OrganisationDataRowValidator : AbstractValidator<OrganisationDataRow>
 {
     private readonly IFeatureManager _featureManager;
-    private bool _validatorsRegistred;
+    private bool _areValidatorsRegistered;
 
     public OrganisationDataRowValidator(IFeatureManager featureManager)
     {
         _featureManager = featureManager;
-        _validatorsRegistred = false;
+        _areValidatorsRegistered = false;
     }
 
-    public void RegisterValidators(bool uploadedByComplianceScheme, bool isSubmissionPeriod2026, DateTime smallProducersRegStartTime2026, DateTime smallProducersRegEndTime2026)
+    public async Task RegisterValidators(
+        bool uploadedByComplianceScheme,
+        string? registrationJourney)
     {
-        if (_validatorsRegistred)
+        if (_areValidatorsRegistered)
         {
             return;
         }
+
+        var isSubsidiaryJoinerLeaverEnabled = _featureManager.IsEnabledAsync(FeatureFlags.EnableSubsidiaryJoinerAndLeaverColumns);
+        var isOrganisationSizeFieldValidationEnabled = _featureManager.IsEnabledAsync(FeatureFlags.EnableOrganisationSizeFieldValidation);
+        var enableAdditionalValidationForJoinerLeaverColumnsTask = _featureManager.IsEnabledAsync(FeatureFlags.EnableAdditionalValidationForJoinerLeaverColumns);
+        var enableLeaverCodeValidationTask = _featureManager.IsEnabledAsync(FeatureFlags.EnableLeaverCodeValidation);
 
         Include(new OrganisationIdValidator());
         Include(new OrganisationNameValidator());
@@ -42,25 +49,25 @@ public class OrganisationDataRowValidator : AbstractValidator<OrganisationDataRo
         Include(new CompanyHouseValidator());
         Include(new OrganisationTypeValidator());
 
-        if (_featureManager != null && _featureManager.IsEnabledAsync(FeatureFlags.EnableSubsidiaryJoinerAndLeaverColumns).Result)
-        {
-            var enableAdditionalValidationForJoinerLeaverColumns = _featureManager.IsEnabledAsync(FeatureFlags.EnableAdditionalValidationForJoinerLeaverColumns).Result;
-            var enableLeaverCodeValidation = _featureManager.IsEnabledAsync(FeatureFlags.EnableLeaverCodeValidation).Result;
+        await Task.WhenAll(isSubsidiaryJoinerLeaverEnabled, isOrganisationSizeFieldValidationEnabled, enableAdditionalValidationForJoinerLeaverColumnsTask, enableLeaverCodeValidationTask);
 
-            Include(new JoinerDateValidator(
-                uploadedByComplianceScheme, enableAdditionalValidationForJoinerLeaverColumns, enableLeaverCodeValidation));
+        if (await isSubsidiaryJoinerLeaverEnabled)
+        {
+            var enableAdditionalValidationForJoinerLeaverColumns = await enableAdditionalValidationForJoinerLeaverColumnsTask;
+            var enableLeaverCodeValidation = await enableLeaverCodeValidationTask;
+            Include(new JoinerDateValidator(uploadedByComplianceScheme, enableAdditionalValidationForJoinerLeaverColumns, enableLeaverCodeValidation));
             Include(new LeaverDateValidator(uploadedByComplianceScheme, enableLeaverCodeValidation));
             Include(new LeaverCodeValidator(uploadedByComplianceScheme, enableLeaverCodeValidation));
             Include(new OrganisationChangeReasonValidator());
             Include(new RegistrationTypeCodeValidator(uploadedByComplianceScheme));
         }
 
-        if (_featureManager != null && _featureManager.IsEnabledAsync(FeatureFlags.EnableOrganisationSizeFieldValidation).Result)
+        if (await isOrganisationSizeFieldValidationEnabled)
         {
-            Include(new OrganisationSizeValidator(uploadedByComplianceScheme, isSubmissionPeriod2026, smallProducersRegStartTime2026, smallProducersRegEndTime2026));
+            Include(new OrganisationSizeValidator(registrationJourney));
             Include(new OrganisationSizeTurnoverValidator());
         }
 
-        _validatorsRegistred = true;
+        _areValidatorsRegistered = true;
     }
 }

--- a/src/EPR.RegistrationValidation.Application/Validators/OrganisationSizeValidator.cs
+++ b/src/EPR.RegistrationValidation.Application/Validators/OrganisationSizeValidator.cs
@@ -1,53 +1,58 @@
 ﻿namespace EPR.RegistrationValidation.Application.Validators
 {
-    using EPR.RegistrationValidation.Application.Constants;
+    using Constants;
+    using Data.Enums;
+    using Data.Models;
     using EPR.RegistrationValidation.Data.Constants;
-    using EPR.RegistrationValidation.Data.Models;
     using FluentValidation;
 
     public class OrganisationSizeValidator : AbstractValidator<OrganisationDataRow>
     {
-        public OrganisationSizeValidator(bool uploadedByComplianceScheme, bool isSubmissionPeriod2026, DateTime smallProducersRegStartTime2026, DateTime smallProducersRegEndTime2026)
+        public OrganisationSizeValidator(string? registrationJourney)
         {
             RuleFor(size => size.OrganisationSize)
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty().WithErrorCode(ErrorCodes.MissingOrganisationSizeValue)
                 .Must(BeValidValue).WithErrorCode(ErrorCodes.InvalidOrganisationSizeValue);
 
-            if (isSubmissionPeriod2026)
+            if (registrationJourney != null)
             {
-                var errorCode = uploadedByComplianceScheme
-                    ? ErrorCodes.InvalidRegistrationWindowForSmallProducers2026CS
-                    : ErrorCodes.InvalidRegistrationWindowForSmallProducers2026DP;
+                var errorCode =
+                    (registrationJourney == RegistrationJourney.CsoLargeProducer.ToString() ||
+                     registrationJourney == RegistrationJourney.DirectLargeProducer.ToString())
+                    ? ErrorCodes.SmallProducerInLargeProducerFile
+                    : ErrorCodes.LargeProducerInSmallProducerFile;
 
                 RuleFor(size => size.OrganisationSize)
                     .Cascade(CascadeMode.Stop)
                     .NotEmpty().WithErrorCode(ErrorCodes.MissingOrganisationSizeValue)
-                    .Must(size =>
-                        BeTimeToRegisterAsSmallProducerFor2026(size, smallProducersRegStartTime2026, smallProducersRegEndTime2026))
+                    .Must(size => BeCorrectSizeForJourneyChosen(size, registrationJourney))
                     .WithErrorCode(errorCode);
             }
+        }
+
+        private static bool BeCorrectSizeForJourneyChosen(string size, string registrationJourney)
+        {
+            if ((registrationJourney.Equals(RegistrationJourney.CsoLargeProducer.ToString()) ||
+                 registrationJourney.Equals(RegistrationJourney.DirectLargeProducer.ToString()))
+                && size.ToUpper() == OrganisationSizeCodes.L.ToString())
+            {
+                return true;
+            }
+            else if ((registrationJourney.Equals(RegistrationJourney.CsoSmallProducer.ToString()) ||
+                      registrationJourney.Equals(RegistrationJourney.DirectSmallProducer.ToString()))
+                     && size.ToUpper() == OrganisationSizeCodes.S.ToString())
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool BeValidValue(string size)
         {
             return !string.IsNullOrEmpty(size)
                 && (Enum.IsDefined(typeof(OrganisationSizeCodes), size.ToUpper()) || Enum.IsDefined(typeof(OrganisationSizeCodes), size.ToLower()));
-        }
-
-        private static bool BeTimeToRegisterAsSmallProducerFor2026(string size, DateTime start, DateTime end)
-        {
-            bool isSmallProducer = string.Equals(size.ToUpper(), OrganisationSizeCodes.S.ToString(), StringComparison.OrdinalIgnoreCase);
-            bool isDateInRange = DateTime.UtcNow >= start && DateTime.UtcNow <= end;
-
-            if (isSmallProducer)
-            {
-                return isDateInRange;
-            }
-            else
-            {
-                return true;
-            }
         }
     }
 }

--- a/src/EPR.RegistrationValidation.Data/Constants/ErrorCodes.cs
+++ b/src/EPR.RegistrationValidation.Data/Constants/ErrorCodes.cs
@@ -107,4 +107,6 @@ public static class ErrorCodes
     public const string LeaverDateIsMandatoryForThisCode = "931";
     /* Issue codes for warnings */
     public const string WarningZeroTurnover = "73";
+    public const string SmallProducerInLargeProducerFile = "932";
+    public const string LargeProducerInSmallProducerFile = "933";
 }

--- a/src/EPR.RegistrationValidation.Data/Enums/RegistrationJourney.cs
+++ b/src/EPR.RegistrationValidation.Data/Enums/RegistrationJourney.cs
@@ -1,0 +1,9 @@
+﻿namespace EPR.RegistrationValidation.Data.Enums;
+
+public enum RegistrationJourney
+{
+    DirectSmallProducer,
+    DirectLargeProducer,
+    CsoSmallProducer,
+    CsoLargeProducer,
+}

--- a/src/EPR.RegistrationValidation.Data/Models/SubmissionApi/OrganisationFileDetailsResponse.cs
+++ b/src/EPR.RegistrationValidation.Data/Models/SubmissionApi/OrganisationFileDetailsResponse.cs
@@ -5,4 +5,6 @@ public class OrganisationFileDetailsResponse
     public string BlobName { get; set; }
 
     public string SubmissionPeriod { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/src/EPR.RegistrationValidation.Functions/Startup.cs
+++ b/src/EPR.RegistrationValidation.Functions/Startup.cs
@@ -3,7 +3,6 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.FeatureManagement;
 using Polly;
-using Polly.Retry;
 using Polly.Timeout;
 
 [assembly: FunctionsStartup(typeof(Startup))]

--- a/src/EPR.RegistrationValidation.UnitTests/Helpers/CSVStreamParserTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Helpers/CSVStreamParserTests.cs
@@ -14,7 +14,7 @@ using TestHelpers;
 [TestClass]
 public class CsvStreamParserTests
 {
-    private CsvStreamParser _sut;
+    private CsvStreamParser _csvStreamParser;
 
     [TestInitialize]
     public void Setup()
@@ -30,7 +30,7 @@ public class CsvStreamParserTests
            .Setup(m => m.IsEnabledAsync(FeatureFlags.EnableStatusCodeColumn))
            .Returns(Task.FromResult(true));
 
-        _sut = new CsvStreamParser(new ColumnMetaDataProvider(featureManageMock.Object), featureManageMock.Object);
+        _csvStreamParser = new CsvStreamParser(new ColumnMetaDataProvider(featureManageMock.Object), featureManageMock.Object);
     }
 
     [TestMethod]
@@ -42,7 +42,7 @@ public class CsvStreamParserTests
         var memoryStream = CsvFileReader.ReadFile("ValidFileWithCorrectHeaders.csv");
 
         // Act
-        var response = await _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
+        var response = await _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
 
         // Assert
         response[0].OrganisationTypeCode.Should().Be(RequiredOrganisationTypeCodeForPartners.PAR.ToString());
@@ -65,7 +65,7 @@ error, error";
         stream.Position = 0;
 
         // Act
-        Func<Task> act = () => _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(stream);
+        Func<Task> act = () => _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(stream);
 
         // Assert
         await act.Should().ThrowAsync<CsvHeaderException>();
@@ -79,7 +79,7 @@ error, error";
         var memoryStream = CsvFileReader.ReadFile(invalidCsvFile);
 
         // Act
-        Func<Task> act = () => _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
+        Func<Task> act = () => _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
 
         // Assert
         await act.Should().ThrowAsync<CsvHeaderException>().WithMessage("The CSV file header is invalid.");
@@ -92,7 +92,7 @@ error, error";
         var memoryStream = CsvFileReader.ReadFile("InvalidFileTooManyHeaders.csv");
 
         // Act
-        Func<Task> act = () => _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
+        Func<Task> act = () => _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
 
         // Assert
         await act.Should().ThrowAsync<CsvHeaderException>().WithMessage("The CSV file header is invalid.");
@@ -105,7 +105,7 @@ error, error";
         var memoryStream = CsvFileReader.ReadFile("InvalidFileTooFewHeaders.csv");
 
         // Act
-        Func<Task> act = () => _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
+        Func<Task> act = () => _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
 
         // Assert
         await act.Should().ThrowAsync<CsvHeaderException>().WithMessage("The CSV file header is invalid.");
@@ -120,7 +120,7 @@ error, error";
         // Act
         Func<Task> act = async () =>
         {
-            await _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
+            await _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
         };
 
         // Assert
@@ -136,7 +136,7 @@ error, error";
         using var memoryStream = CsvFileReader.ReadFile("ValidFileWithCorrectHeaders.csv");
 
         // Act
-        var items = await _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
+        var items = await _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
 
         // Assert
         items.Should().HaveCount(2);
@@ -151,7 +151,7 @@ error, error";
         using var memoryStream = CsvFileReader.ReadFile("ValidFileWithCorrectHeaders.csv");
 
         // Act
-        var items = await _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
+        var items = await _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream, useMinimalClassMaps);
 
         // Assert
         items.Should().HaveCount(2);
@@ -166,7 +166,7 @@ error, error";
         using var memoryStream = CsvFileReader.ReadFile("ValidFileWithCorrectHeaders.csv");
 
         // Act
-        var items = await _sut.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
+        var items = await _csvStreamParser.GetItemsFromCsvStreamAsync<OrganisationDataRow>(memoryStream);
 
         // Assert minimal set of properties are not empty
         foreach (var row in items)
@@ -195,7 +195,7 @@ error, error";
         using var memoryStream = CsvFileReader.ReadString(csvString);
 
         // Act
-        var items = await _sut.GetItemsFromCsvStreamAsync<BrandDataRow>(memoryStream, useMinimalClassMaps);
+        var items = await _csvStreamParser.GetItemsFromCsvStreamAsync<BrandDataRow>(memoryStream, useMinimalClassMaps);
 
         // Assert
         items[0].DefraId.Should().Be(defraId);
@@ -223,7 +223,7 @@ error, error";
         using var memoryStream = CsvFileReader.ReadString(csvString);
 
         // Act
-        var items = await _sut.GetItemsFromCsvStreamAsync<PartnersDataRow>(memoryStream, useMinimalClassMaps);
+        var items = await _csvStreamParser.GetItemsFromCsvStreamAsync<PartnersDataRow>(memoryStream, useMinimalClassMaps);
 
         // Assert
         items[0].DefraId.Should().Be(defraId);

--- a/src/EPR.RegistrationValidation.UnitTests/Providers/DequeueProviderTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Providers/DequeueProviderTests.cs
@@ -11,7 +11,7 @@ using TestHelpers;
 [TestClass]
 public class DequeueProviderTests
 {
-    private DequeueProvider _sut = new();
+    private readonly DequeueProvider _dequeueProvider = new();
 
     [TestInitialize]
     public void SetUp()
@@ -32,7 +32,7 @@ public class DequeueProviderTests
         var message = QueueMessageTestHelper.GenerateMessage(blobName, submissionId, submissionSubType.ToString(), userId, organisationId, complianceSchemeId, userType);
 
         // Act
-        var response = _sut.GetMessageFromJson<BlobQueueMessage>(message);
+        var response = _dequeueProvider.GetMessageFromJson<BlobQueueMessage>(message);
 
         // Assert
         response.OrganisationId.Should().Be(organisationId);
@@ -51,7 +51,7 @@ public class DequeueProviderTests
         var message = "invalid";
 
         // Act
-        Action act = () => _sut.GetMessageFromJson<BlobQueueMessage>(message);
+        Action act = () => _dequeueProvider.GetMessageFromJson<BlobQueueMessage>(message);
 
         // Assert
         act.Should().Throw<DeserializeQueueException>();

--- a/src/EPR.RegistrationValidation.UnitTests/Services/RegistrationServiceTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Services/RegistrationServiceTests.cs
@@ -1447,7 +1447,6 @@ public class RegistrationServiceTests
     {
         // Arrange
         var blobName = "test";
-        var registrationBlobName = "registrationblob";
         var submissionId = Guid.NewGuid().ToString();
         var userId = Guid.NewGuid().ToString();
         var organisationId = Guid.NewGuid().ToString();
@@ -1506,9 +1505,7 @@ public class RegistrationServiceTests
     [TestMethod]
     public void ProcessServiceBusMessage_BrandPartnerCrossFileValidationFeature_Empty_OrganisationFile_Logs_Error()
     {
-        // Arrange
         var blobName = "test";
-        var registrationBlobName = "registrationblob";
         var submissionId = Guid.NewGuid().ToString();
         var userId = Guid.NewGuid().ToString();
         var organisationId = Guid.NewGuid().ToString();

--- a/src/EPR.RegistrationValidation.UnitTests/Validators/BrandDataRowOrganisationDataValidatorTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Validators/BrandDataRowOrganisationDataValidatorTests.cs
@@ -42,7 +42,6 @@ public class BrandDataRowOrganisationDataValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().NotBeEmpty();
         result.ShouldHaveValidationErrorFor(x => x.DefraId);
-        var x = nameof(BrandDataRow.DefraId);
         result.Errors.Should().Contain(x =>
             x.PropertyName == nameof(BrandDataRow.DefraId) &&
             x.ErrorCode == ErrorCodes.BrandDetailsNotMatchingOrganisation);

--- a/src/EPR.RegistrationValidation.UnitTests/Validators/OrganisationIdValidatorTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Validators/OrganisationIdValidatorTests.cs
@@ -12,14 +12,11 @@ public class OrganisationIdValidatorTests
     [TestMethod]
     public async Task Validate_WithNullOrganisationId_IsNotValid()
     {
-        // Arrange
         var validator = CreateValidator();
         var orgDataRow = new OrganisationDataRow();
 
-        // Act
         var result = await validator.TestValidateAsync(orgDataRow);
 
-        // Assert
         result.IsValid.Should().BeFalse();
         result.Errors.Should().NotBeEmpty();
         result.ShouldHaveValidationErrorFor(x => x.DefraId);
@@ -28,52 +25,17 @@ public class OrganisationIdValidatorTests
     [TestMethod]
     public async Task Validate_WithOrganisationId_IsValid()
     {
-        // Arrange
         var validator = CreateValidator();
         var orgDataRow = new OrganisationDataRow { DefraId = "1234567890" };
 
-        // Act
         var result = await validator.TestValidateAsync(orgDataRow);
 
-        // Assert
         result.IsValid.Should().BeTrue();
         result.Errors.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public async Task Validate_WhenOrganisationSizeIsSmall_ReturnCorrectResultBasedOnRegDate()
-    {
-        // Arrange
-        var validator = CreateOrganisationSizeValidator(false, true);
-        var orgDataRow = new OrganisationDataRow { DefraId = "1234567890", OrganisationSize = "s" };
-
-        // Act
-        var result = await validator.TestValidateAsync(orgDataRow);
-
-        // Assert
-        // Small producers registration window for 2026
-        if (DateTime.UtcNow >= new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) && DateTime.UtcNow <= new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Unspecified))
-        {
-            result.IsValid.Should().BeTrue();
-            result.Errors.Should().BeEmpty();
-        }
-        else
-        {
-            result.IsValid.Should().BeFalse();
-            result.Errors.Should().NotBeEmpty();
-        }
     }
 
     private static OrganisationIdValidator CreateValidator()
     {
         return new OrganisationIdValidator();
-    }
-
-    private static OrganisationSizeValidator CreateOrganisationSizeValidator(bool uploadedByComplianceScheme, bool isSubmissionPeriod2026)
-    {
-        DateTime smallProducersRegStartTime2026 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        DateTime smallProducersRegEndTime2026 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        return new OrganisationSizeValidator(uploadedByComplianceScheme, isSubmissionPeriod2026, smallProducersRegStartTime2026, smallProducersRegEndTime2026);
     }
 }

--- a/src/EPR.RegistrationValidation.UnitTests/Validators/OrganisationSizeTurnoverValidatorTests.cs
+++ b/src/EPR.RegistrationValidation.UnitTests/Validators/OrganisationSizeTurnoverValidatorTests.cs
@@ -28,9 +28,7 @@ public class OrganisationSizeTurnoverValidatorTests
 
         // Assert
         result.IsValid.Should().Be(testResult);
-
-        // result.Errors.Should().NotBeEmpty();
-        result.Errors.Count().Should().Be(errorCount);
+        result.Errors.Count.Should().Be(errorCount);
     }
 
     [TestMethod]


### PR DESCRIPTION
* SMAL-118: Updating OrgnisationSize validation to be based on Registration Journey selected not hard coded date periods, updated tests, and claening up a bit of other code I looked over.

* Adding Enum based on PR feedback

* Adding WhenAll for tasks in registration, awaiting the registration of validators, and removing unused variable and assignment.